### PR TITLE
Add glob support for turbopuffer filtering

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -173,6 +173,10 @@ struct Cli {
     /// Show distance scores in output (lower is better)
     #[arg(long)]
     scores: bool,
+
+    /// Filter files by glob (repeatable)
+    #[arg(short = 'g', long = "glob", value_name = "GLOB")]
+    glob: Vec<String>,
 }
 
 #[tokio::main]
@@ -271,6 +275,7 @@ async fn main() {
                 cli.max_count,
                 cli.embedding_concurrency,
                 cli.scores,
+                &cli.glob,
             )
             .await
             {
@@ -288,6 +293,7 @@ async fn main() {
                 cli.max_count,
                 cli.embedding_concurrency,
                 cli.scores,
+                &cli.glob,
             )
             .await
             {
@@ -304,6 +310,7 @@ async fn main() {
                 cli.max_count,
                 cli.embedding_concurrency,
                 cli.scores,
+                &cli.glob,
             )
             .await
             {


### PR DESCRIPTION
Add `--glob` support to filter search results by file path, leveraging turbopuffer's glob filtering capabilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-95924580-09a6-4c8d-a3e4-2458807e3c74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-95924580-09a6-4c8d-a3e4-2458807e3c74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

